### PR TITLE
Fixed exception on capture

### DIFF
--- a/sleepypuppy/collector/views.py
+++ b/sleepypuppy/collector/views.py
@@ -57,7 +57,7 @@ def email_subscriptions(xss_uid, url):
         cgi.escape(url, quote=True)
     )
     html += "<b>Parameter: </b>{}<br/>".format(
-        cgi.escape(notify_jobs.parameter, quote=True)
+        cgi.escape(notify_jobs.parameter or "", quote=True)
     )
     html += "<b>Payload: </b>{}<br/>".format(
         cgi.escape(notify_jobs.payload, quote=True)


### PR DESCRIPTION
In my environment a capture event caused an exception because notify_jobs.parameter was not set. Fixed it by introduction of an empty default value in the cgi.escape call.
